### PR TITLE
feat: add darwin/arm64 as a release target

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,7 @@ builds:
   - darwin
   goarch:
   - amd64
+  - arm64
 
 archives:
 - builds:


### PR DESCRIPTION
Adds `arm64` as a build target to better support users with M1 Macs. 
